### PR TITLE
special displaying of user created setups

### DIFF
--- a/src/lib/components/SetupView/SetupItem.svelte
+++ b/src/lib/components/SetupView/SetupItem.svelte
@@ -31,6 +31,9 @@
         <div class="hidden md:block">{motherboard}</div>
         <div class="hidden xl:block">{psu}</div>
         <div class="hidden 2xl:block">{os}</div>
+        {#if setup.status == "pending"}
+            <div class="badge badge-sm badge-soft badge-primary absolute right-0 mr-2">awaiting Approval</div>
+        {/if}
     </div>
     <div class="collapse-content grid grid-cols-subgrid col-span-8 p-0 text-xs">
         <CollapsedSetupView {setup}/>

--- a/src/lib/components/SetupView/SetupItem.svelte
+++ b/src/lib/components/SetupView/SetupItem.svelte
@@ -32,7 +32,7 @@
         <div class="hidden xl:block">{psu}</div>
         <div class="hidden 2xl:block">{os}</div>
         {#if setup.status == "pending"}
-            <div class="badge badge-sm badge-soft badge-primary absolute right-0 mr-2">awaiting Approval</div>
+            <div class="badge badge-sm badge-soft badge-primary absolute right-0 mr-2">awaiting approval</div>
         {/if}
     </div>
     <div class="collapse-content grid grid-cols-subgrid col-span-8 p-0 text-xs">

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -5,6 +5,8 @@ export function load({}) {
     refreshUserState();
 
     return {
-        setups: pb.collection('setups').getFullList<SetupRecord>()
+        setups: pb.collection('setups').getFullList<SetupRecord>({
+            sort: "-status,idle"
+        })
     };
 }


### PR DESCRIPTION
![Screenshot_20250427_172808](https://github.com/user-attachments/assets/bf3e53de-86a4-4139-9a07-41a69267649b)
When a user is logged in and has "open" (not yet approved) setups he created, it lists them at the top of the setups list with a special badge clarifying that these are not yet public.

This provides the user instant feedback when contributing setups :)

Designs + colors are a bit WIP