### PR TITLE
Feature/auto reload

### DIFF
--- a/src/lib/auth.svelte.ts
+++ b/src/lib/auth.svelte.ts
@@ -1,3 +1,4 @@
+import { invalidate } from "$app/navigation";
 import { pb } from "$lib/api"
 
 
@@ -30,6 +31,10 @@ export const user = new User();
 export const loginWithGithub = async () => {
   return pb.collection("users").authWithOAuth2({ provider: "github" }).then((authData) => {
     refreshUserState();
+
+    // when logged in, reload setups to also show users pending additions
+    invalidate("app:setups");
+
     return authData;
   });
 }
@@ -37,6 +42,9 @@ export const loginWithGithub = async () => {
 export const logout = () => {
   pb.authStore.clear();
   refreshUserState();
+
+  // same as in `loginWithGithub`
+  invalidate("app:setups");
 }
 
 export const refreshUserState = () => {

--- a/src/lib/components/AddSetup/Summary.svelte
+++ b/src/lib/components/AddSetup/Summary.svelte
@@ -4,6 +4,7 @@
     import SummaryBlock from "$lib/components/AddSetup/SummaryBlock.svelte";
 
     import {input} from "$lib/components/AddSetup/state.svelte";
+    import { invalidate } from "$app/navigation";
 
     let infoText = "Setup Summary";
 
@@ -26,7 +27,10 @@
         // right now the request just won't work
         submitData.user = pb.authStore.record?.id;
 
-        submitPromise = pb.collection('setups').create(submitData);
+        submitPromise = pb.collection('setups').create(submitData).then(() => {
+            // if succesfully added -> refresh setups
+            invalidate("app:setups");
+        });
     };
 </script>
 

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -2,8 +2,10 @@ import { pb } from "$lib/api";
 import { refreshUserState } from "$lib/auth.svelte";
 import type { SetupRecord } from "$lib/api/types";
 
-export function load({ fetch }) {
+export function load({ fetch, depends }) {
     refreshUserState();
+
+    depends("app:setups");
 
     return {
         setups: pb.collection('setups').getFullList<SetupRecord>({

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -2,11 +2,12 @@ import { pb } from "$lib/api";
 import { refreshUserState } from "$lib/auth.svelte";
 import type { SetupRecord } from "$lib/api/types";
 
-export function load({}) {
+export function load({ fetch }) {
     refreshUserState();
 
     return {
         setups: pb.collection('setups').getFullList<SetupRecord>({
+            fetch: fetch,
             sort: "-status,idle",
             requestKey: null
         })


### PR DESCRIPTION
first implementation for #8

Svelte provides [a handy feature](https://svelte.dev/docs/kit/load#Rerunning-load-functions-Manual-invalidation) for invalidating data fetched from a +page.ts `load()` function.

Normally you would just pass the URL of your API to `invalidate()` and then svelte handles the rest. But as we don't make the fetch call directly and instead use the pocketbase API, I instead defined the custom URL `app:setups`, which then can be invalidated when you have to refetch the setups.

This currently happens on login, logout & when a user adds a setup.

Currently this invalidation causes the main page to show the loading text again (like on a page refresh), while loading. Maybe it would be better/less disruptive to keep the old data until the new one is loaded, and then swap the new one in? 